### PR TITLE
Please DO squash and remove double bracket from JIRA link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,7 +2,7 @@
 
 Resolves [LRE-XXXX](https://seismic.atlassian.net/browse/LRE-XXXX)
 
-What is the problem this PR attempts to solve, and why is it important? Fixing a bug? Explain the problem you're solving. Laying a foundation for future work? Explain how this fits into the bigger picture. Don't forget to link to the Shortcut issue above.
+What is the problem this PR attempts to solve, and why is it important? Fixing a bug? Explain the problem you're solving. Laying a foundation for future work? Explain how this fits into the bigger picture. Don't forget to link to the Jira issue above.
 
 ## What?
 
@@ -24,7 +24,7 @@ _List any steps a reviewer should take to prepare for testing, but that aren't a
 
 ### Feature testing steps:
 
-_List all steps to test the feature. Try to split up steps into managable sections so the review can work in batches_
+_List all steps to test the feature. Try to split up steps into manageable sections so the review can work in batches_
 
 **Section Name**
 

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,6 +1,6 @@
 ## Why?
 
-Resolves [[LRE-XXXX]](https://seismic.atlassian.net/browse/LRE-XXXX)
+Resolves [LRE-XXXX](https://seismic.atlassian.net/browse/LRE-XXXX)
 
 What is the problem this PR attempts to solve, and why is it important? Fixing a bug? Explain the problem you're solving. Laying a foundation for future work? Explain how this fits into the bigger picture. Don't forget to link to the Shortcut issue above.
 
@@ -74,4 +74,4 @@ Were there articles or StackOverflow answers you found especially eye-opening wh
 
 ## Merge Instructions
 
-Please **DO NOT** squash my commits when merging
+Please **DO** squash my commits when merging


### PR DESCRIPTION
## Why?

Resolves [LRE-5067](https://seismic.atlassian.net/browse/LRE-5067)

The repository has been switched to squash by default but the PR template says do not squash which can be confusing.

While discussing this during the architecture talks, I was also asked to remove the brackets from the JIRA link.

## What?

This PR removes "NOT" from the squash message and one of the sets of brackets from the JIRA link.

## Merge Instructions

Please **DO** squash my commits when merging


[LRE-5067]: https://seismic.atlassian.net/browse/LRE-5067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ